### PR TITLE
Easy rules and easy state implementation of track and album art processing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,10 @@
             <id>jaudiotagger-repository</id>
             <url>https://dl.bintray.com/ijabz/maven</url>
         </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
+        </repository>
     </repositories>
 
     <build>
@@ -109,9 +113,9 @@
             <version>1.53h</version>
         </dependency>
         <dependency>
-            <groupId>net.jthink</groupId>
+            <groupId>com.github.goxr3plus</groupId>
             <artifactId>jaudiotagger</artifactId>
-            <version>2.2.3</version>
+            <version>2.2.7</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,16 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-rules-core</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jeasy</groupId>
+            <artifactId>easy-states</artifactId>
+            <version>2.0.0</version>
+        </dependency>
+        <dependency>
             <groupId>net.imagej</groupId>
             <artifactId>ij</artifactId>
             <version>1.53h</version>

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -10,6 +10,7 @@ import org.jaudiotagger.tag.images.Artwork
 import org.jaudiotagger.tag.images.StandardArtwork
 import java.io.File
 import java.io.FileNotFoundException
+import java.io.IOException
 import java.math.BigInteger
 import java.security.MessageDigest
 import java.util.logging.Logger
@@ -86,9 +87,10 @@ object Tag {
         try {
             val albumArt = StandardArtwork.createArtworkFromFile(File("$mp3AlbumPath/${Config.coverArtFile}"))
             tag.addField(albumArt)
-            tag.createField(albumArt)
             logger.warning("Fields finally in mp3 $mp3AlbumPath: ${tag.fieldCount}")
         } catch (e: FieldDataInvalidException) {
+            ImageScaler.logger.warning("Could not tag file with album art: $mp3AlbumPath/${Config.coverArtFile}")
+        } catch (e: IOException) {
             ImageScaler.logger.warning("Could not find album art for tagging: $mp3AlbumPath/${Config.coverArtFile}")
         }
 

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -60,12 +60,7 @@ object Tag {
         val f = AudioFileIO.read(File(mp3File))
         f.tag = ID3v24Tag()
         val tag = f.tag
-        // TODO: Put this try block in addAlbumArtField()
-        try {
-            addAlbumArtField(mp3AlbumPath, tag)
-        } catch (e: FileNotFoundException) {
-            ImageScaler.logger.warning("Could not find album art for tagging: $mp3AlbumPath/${Config.coverArtFile}")
-        }
+        addAlbumArtField(mp3AlbumPath, tag)
         tag.setField(FieldKey.ARTIST, flacTags.artist)
         tag.setField(FieldKey.ALBUM, flacTags.album)
         tag.setField(FieldKey.TITLE, flacTags.title)

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -3,6 +3,7 @@ package com.eigenholser.flac2mp3
 import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.tag.FieldKey
 import org.jaudiotagger.tag.id3.ID3v23Tag
+import org.jaudiotagger.tag.images.Artwork
 import org.jaudiotagger.tag.images.StandardArtwork
 import java.io.File
 import java.io.FileNotFoundException
@@ -56,6 +57,7 @@ object Tag {
         val f = AudioFileIO.read(File(mp3File))
         f.tag = ID3v23Tag()
         val tag = f.tag
+        // TODO: Put this try block in addAlbumArtField()
         try {
             val albumArt = StandardArtwork.createArtworkFromFile(File("$mp3AlbumPath/${Config.coverArtFile}"))
             tag.addField(albumArt)
@@ -71,5 +73,25 @@ object Tag {
         // TODO: How does this work?
 //        tag.createField(FieldKey.valueOf("CDDB"), flacTags.cddb)
         f.commit()
+    }
+
+    fun getAlbumArt(mp3File: File): Artwork {
+        val f = AudioFileIO.read(File(mp3File.path))
+        val tag = f.tag // TODO: Is this null if the MP3 has not been tagged? try/catch?
+        // If this is null there is no artwork?? Prove this hypothesis.
+        return tag.firstArtwork
+    }
+
+    fun addAlbumArtField() {
+
+    }
+
+    fun deleteAlbumArtField() {
+
+    }
+
+    fun updateAlbumArtField() {
+        deleteAlbumArtField()
+        addAlbumArtField()
     }
 }

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -75,11 +75,12 @@ object Tag {
         f.commit()
     }
 
-    fun getAlbumArt(mp3File: File): Artwork {
+    fun albumArtExists(mp3File: File): Boolean {
         val f = AudioFileIO.read(mp3File)
         val tag = f.tag // TODO: Is this null if the MP3 has not been tagged? try/catch?
         // If this is null there is no artwork?? Prove this hypothesis.
-        return tag.firstArtwork
+        val artwork = tag.firstArtwork
+        return artwork != null
     }
 
     fun addAlbumArtField() {

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -76,7 +76,7 @@ object Tag {
     }
 
     fun getAlbumArt(mp3File: File): Artwork {
-        val f = AudioFileIO.read(File(mp3File.path))
+        val f = AudioFileIO.read(mp3File)
         val tag = f.tag // TODO: Is this null if the MP3 has not been tagged? try/catch?
         // If this is null there is no artwork?? Prove this hypothesis.
         return tag.firstArtwork

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -62,8 +62,7 @@ object Tag {
         val tag = f.tag
         // TODO: Put this try block in addAlbumArtField()
         try {
-            val albumArt = StandardArtwork.createArtworkFromFile(File("$mp3AlbumPath/${Config.coverArtFile}"))
-            tag.addField(albumArt)
+            addAlbumArtField(mp3AlbumPath, tag)
         } catch (e: FileNotFoundException) {
             ImageScaler.logger.warning("Could not find album art for tagging: $mp3AlbumPath/${Config.coverArtFile}")
         }
@@ -112,5 +111,6 @@ object Tag {
         val tag = f.tag
         deleteAlbumArtField(tag)
         addAlbumArtField(mp3AlbumPath, tag)
+        f.commit()
     }
 }

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -67,6 +67,7 @@ object Tag {
         tag.setField(FieldKey.YEAR, flacTags.year)
         tag.setField(FieldKey.GENRE, flacTags.genre)
         tag.setField(FieldKey.TRACK, flacTags.track)
+        logger.warning("Fields finally in mp3 $mp3AlbumPath: ${tag.fieldCount}")
         // TODO: How does this work?
 //        tag.createField(FieldKey.valueOf("CDDB"), flacTags.cddb)
         f.commit()
@@ -85,6 +86,7 @@ object Tag {
         try {
             val albumArt = StandardArtwork.createArtworkFromFile(File("$mp3AlbumPath/${Config.coverArtFile}"))
             tag.addField(albumArt)
+            tag.createField(albumArt)
             logger.warning("Fields finally in mp3 $mp3AlbumPath: ${tag.fieldCount}")
         } catch (e: FieldDataInvalidException) {
             ImageScaler.logger.warning("Could not find album art for tagging: $mp3AlbumPath/${Config.coverArtFile}")
@@ -93,6 +95,7 @@ object Tag {
     }
 
     private fun deleteAlbumArtField(tag: Tag) {
+        logger.warning("${tag.artworkList}")
         try {
             tag.deleteArtworkField()
         } catch (e: KeyNotFoundException) {
@@ -102,9 +105,10 @@ object Tag {
 
     fun updateAlbumArtField(mp3File: String, mp3AlbumPath: String) {
         val f = AudioFileIO.read(File(mp3File))
-        f.tag = ID3v24Tag()
         val tag = f.tag
-        deleteAlbumArtField(tag)
+        if (tag.firstArtwork != null) {
+            deleteAlbumArtField(tag)
+        }
         addAlbumArtField(mp3AlbumPath, tag)
         f.commit()
     }

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -2,7 +2,7 @@ package com.eigenholser.flac2mp3
 
 import org.jaudiotagger.audio.AudioFileIO
 import org.jaudiotagger.tag.FieldKey
-import org.jaudiotagger.tag.id3.ID3v23Tag
+import org.jaudiotagger.tag.id3.ID3v24Tag
 import org.jaudiotagger.tag.images.Artwork
 import org.jaudiotagger.tag.images.StandardArtwork
 import java.io.File
@@ -55,7 +55,7 @@ object Tag {
 
     fun writeMp3Tags(mp3File: String, mp3AlbumPath: String, flacTags: FlacTags): Unit {
         val f = AudioFileIO.read(File(mp3File))
-        f.tag = ID3v23Tag()
+        f.tag = ID3v24Tag()
         val tag = f.tag
         // TODO: Put this try block in addAlbumArtField()
         try {

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -6,10 +6,8 @@ import org.jaudiotagger.tag.FieldKey
 import org.jaudiotagger.tag.KeyNotFoundException
 import org.jaudiotagger.tag.Tag
 import org.jaudiotagger.tag.id3.ID3v24Tag
-import org.jaudiotagger.tag.images.Artwork
 import org.jaudiotagger.tag.images.StandardArtwork
 import java.io.File
-import java.io.FileNotFoundException
 import java.io.IOException
 import java.math.BigInteger
 import java.security.MessageDigest
@@ -76,9 +74,7 @@ object Tag {
 
     fun albumArtTagExists(mp3File: File): Boolean {
         val f = AudioFileIO.read(mp3File)
-        val tag = f.tag // TODO: Is this null if the MP3 has not been tagged? try/catch?
-        // If this is null there is no artwork?? Prove this hypothesis.
-        val artwork = tag.firstArtwork
+        val artwork = f.tag?.firstArtwork
         return artwork != null
     }
 
@@ -93,7 +89,6 @@ object Tag {
         } catch (e: IOException) {
             ImageScaler.logger.warning("Could not find album art for tagging: $mp3AlbumPath/${Config.coverArtFile}")
         }
-
     }
 
     private fun deleteAlbumArtField(tag: Tag) {

--- a/src/main/kotlin/Tags.kt
+++ b/src/main/kotlin/Tags.kt
@@ -74,7 +74,7 @@ object Tag {
         f.commit()
     }
 
-    fun albumArtExists(mp3File: File): Boolean {
+    fun albumArtTagExists(mp3File: File): Boolean {
         val f = AudioFileIO.read(mp3File)
         val tag = f.tag // TODO: Is this null if the MP3 has not been tagged? try/catch?
         // If this is null there is no artwork?? Prove this hypothesis.

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -43,7 +43,10 @@ fun main(args: Array<String>) {
                 // TODO: If above is true, is FLAC album_art.png newer than MP3 file?
                 // TODO: If this is not null... we have album art. Then read mtime on MP3 file.
                 if (mp3FileExists(it)) {
-                    Tag.getAlbumArt(it.mp3FileAbsolute)
+                    val flag = Tag.albumArtExists(it.mp3FileAbsolute)
+                    if (!flag) {
+                        println("******************** ALBUM ART EXISTS ********************")
+                    }
                 }
 
                 ImageScaler.scaleImage(

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -52,7 +52,7 @@ fun main(args: Array<String>) {
                 )
             }
             // TODO: Only do the stuff below if we're building new MP3
-            if (isTrackCurrent(it)) {
+            if (!isTrackCurrent(it)) {
                 LameFlac2Mp3.flac2mp3(
                     it.flacFileAbsolute.toString(),
                     it.mp3FileAbsolute.toString(),

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -86,9 +86,9 @@ fun main(args: Array<String>) {
 
             val rules = Rules(NewAlbum())
             val facts = Facts()
-            facts.add(Fact("AlbumState", albumStateMachine))
-            facts.add(Fact("currentAlbum", it.currentAlbum))
-            facts.add(Fact("nextAlbum", state.nextAlbum))
+            facts.add(Fact(AlbumFact.ALBUM_STATE.toString(), albumStateMachine))
+            facts.add(Fact(AlbumFact.CURRENT_ALBUM.toString(), it.currentAlbum))
+            facts.add(Fact(AlbumFact.NEXT_ALBUM.toString(), state.nextAlbum))
             rulesEngine.fire(rules, facts)
 
             if (isNewAlbum(rules, facts)) {
@@ -96,8 +96,8 @@ fun main(args: Array<String>) {
             }
 
             if (AlbumState.valueOf(albumStateMachine.currentState.name) == AlbumState.NEW_ALBUM) {
-                albumStateMachine.fire(ExistingAlbumEvent())
                 println("Album State: ${albumStateMachine.currentState.name}")
+                albumStateMachine.fire(ExistingAlbumEvent())
                 state.switchAlbum = true
                 state.nextAlbum = it.currentAlbum
                 deleteMp3CoverArt(state.prevMp3AlbumPath)

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -43,8 +43,8 @@ fun main(args: Array<String>) {
     FlacDatabase.createDatabase()
 
     val state = ConversionState()
-    val newAlbum = State("newAlbum")
-    val existingAlbum = State("existingAlbum")
+    val newAlbum = State(AlbumState.NEW_ALBUM.toString())
+    val existingAlbum = State(AlbumState.EXISTING_ALBUM.toString())
     val states = mutableSetOf(newAlbum, existingAlbum)
 
     val newAlbumTx = TransitionBuilder()

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -16,6 +16,7 @@ fun main(args: Array<String>) {
 
     var switchAlbum = false
     var nextAlbum = ""
+    var prevMp3AlbumPath: Path? = null
 
     File(Config.flacRoot)
         .walk()
@@ -38,6 +39,9 @@ fun main(args: Array<String>) {
             if (!switchAlbum && it.currentAlbum != nextAlbum) {
                 switchAlbum = true
                 nextAlbum = it.currentAlbum
+                // XXX: Delete previous cover.jpg on album switch
+                deleteMp3CoverArt(prevMp3AlbumPath)
+                prevMp3AlbumPath = it.mp3AlbumPathAbsolute
             }
             if (switchAlbum) {
                 switchAlbum = false
@@ -61,11 +65,9 @@ fun main(args: Array<String>) {
 
             // TODO: Only do the stuff below if we're updating album art
             // TODO: Write the code to update album art.
-
-            // TODO: delete cover.jpg
         }
-
-
+    // Get the last album
+    deleteMp3CoverArt(prevMp3AlbumPath)
 }
 
 data class TrackData(
@@ -115,5 +117,13 @@ fun shouldWeProcessThisTrack(trackData: TrackData): Boolean {
 
 fun shouldWeUpdateAlbumArt(trackData: TrackData): Boolean {
     // do something
+    return false
+}
+
+fun deleteMp3CoverArt(mp3AlbumPathAbsolute: Path?): Boolean {
+    if (mp3AlbumPathAbsolute != null) {
+        val mp3CoverArtFile = File("${mp3AlbumPathAbsolute.toString()}/${Config.coverArtFile}")
+        return mp3CoverArtFile.delete()
+    }
     return false
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -30,6 +30,7 @@ fun main(args: Array<String>) {
             //val flacRow = FlacDatabase.getByCddbAndTrack(tags.cddb, tags.track)
             convertRow(flacfile, fsize, mtime.toMillis())
         }
+
         .filter (::shouldWeProcessThisTrack)
         .forEach {
             println(it)
@@ -48,6 +49,7 @@ fun main(args: Array<String>) {
                     it.mp3AlbumPathAbsolute.toString()
                 )
             }
+            // TODO: Only do the stuff below if we're building new MP3
             LameFlac2Mp3.flac2mp3(
                 it.flacFileAbsolute.toString(),
                 it.mp3FileAbsolute.toString(),
@@ -55,9 +57,12 @@ fun main(args: Array<String>) {
             )
             val flacTags = Tag.readFlacTags(it.flacFileAbsolute.toString())
             Tag.writeMp3Tags(it.mp3FileAbsolute.toString(), it.mp3AlbumPathAbsolute.toString(), flacTags)
-            // TODO: Delete MP3 cover.jpg
-            // TODO: Store MP3 cover.jpg mtime and fsize in DB album table.
+
+            // TODO: Only do the stuff below if we're updating album art
+            // TODO: Write the code to update album art.
         }
+
+
 }
 
 data class TrackData(
@@ -96,6 +101,16 @@ fun mp3FileExists(trackData: TrackData): Boolean {
     return trackData.mp3FileAbsolute.exists()
 }
 
+fun isAlbumArtCurrent(trackData: TrackData): Boolean {
+    // TODO: check state
+    return true
+}
+
 fun shouldWeProcessThisTrack(trackData: TrackData): Boolean {
-    return (!isTrackCurrent(trackData) || !mp3FileExists(trackData))
+    return (!isTrackCurrent(trackData) || !mp3FileExists(trackData) || shouldWeUpdateAlbumArt(trackData))
+}
+
+fun shouldWeUpdateAlbumArt(trackData: TrackData): Boolean {
+    // do something
+    return false
 }

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -84,30 +84,30 @@ fun main(args: Array<String>) {
             println(it)
             println("Album State: ${albumStateMachine.currentState.name}")
 
-            val rules = Rules(NewAlbum())
+            val rules = Rules(NewAlbum(albumStateMachine))
             val facts = Facts()
             facts.add(Fact(AlbumFact.ALBUM_STATE.toString(), albumStateMachine))
             facts.add(Fact(AlbumFact.CURRENT_ALBUM.toString(), it.currentAlbum))
             facts.add(Fact(AlbumFact.NEXT_ALBUM.toString(), state.nextAlbum))
             rulesEngine.fire(rules, facts)
 
-            if (isNewAlbum(rules, facts)) {
-                albumStateMachine.fire(NewAlbumEvent())
-            }
+//            if (isNewAlbum(rules, facts)) {
+//                albumStateMachine.fire(NewAlbumEvent())
+//            }
 
             if (AlbumState.valueOf(albumStateMachine.currentState.name) == AlbumState.NEW_ALBUM) {
                 println("Album State: ${albumStateMachine.currentState.name}")
                 albumStateMachine.fire(ExistingAlbumEvent())
-                state.switchAlbum = true
+//                state.switchAlbum = true
                 state.nextAlbum = it.currentAlbum
                 deleteMp3CoverArt(state.prevMp3AlbumPath)
                 state.prevMp3AlbumPath = it.mp3AlbumPathAbsolute
             }
 
             if (AlbumState.valueOf(albumStateMachine.currentState.name) == AlbumState.EXISTING_ALBUM) {
-                albumStateMachine.fire(ExistingAlbumEvent())
+//                albumStateMachine.fire(ExistingAlbumEvent())
                 println("Album State: ${albumStateMachine.currentState.name}")
-                state.switchAlbum = false
+//                state.switchAlbum = false
                 Files.createDirectories(it.mp3AlbumPathAbsolute)
                 if (mp3FileExists(it)) {
                     val flag = Tag.albumArtExists(it.mp3FileAbsolute)

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -42,8 +42,9 @@ fun main(args: Array<String>) {
             if (switchAlbum) {
                 switchAlbum = false
                 Files.createDirectories(it.mp3AlbumPathAbsolute)
-                // TODO: Does MP3 cover.jpg exist && FLAC album_art.png exist?
-                // TODO: If above is true, is FLAC album_art.png newer than MP3 cover.jpg?
+                // TODO: Does MP3 exist && FLAC album_art.png exist?
+                // TODO: If above is true, is FLAC album_art.png newer than MP3 file?
+                Tag.getAlbumArt(it.mp3FileAbsolute) // TODO: If this is not null... we have album art. Then read mtime on MP3 file.
                 ImageScaler.scaleImage(
                     it.flacAlbumPathAbsolute.toString(),
                     it.mp3AlbumPathAbsolute.toString()
@@ -60,6 +61,8 @@ fun main(args: Array<String>) {
 
             // TODO: Only do the stuff below if we're updating album art
             // TODO: Write the code to update album art.
+
+            // TODO: delete cover.jpg
         }
 
 

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -19,12 +19,14 @@ import java.util.logging.Logger
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.exists
 
-data class ConversionState(/* var switchAlbum: Boolean = false, */var nextAlbum: String = "",
-                           var prevMp3AlbumPath: Path? = null/*, var albumArtUpdate: Boolean = false*/,
-                           var tagAlbumArt: Boolean = false)
+data class ConversionState(var nextAlbum: String = "", var prevMp3AlbumPath: Path? = null)
 
-class NewAlbumEvent : AbstractEvent("NewAlbumEvent")
-class ExistingAlbumEvent : AbstractEvent("ExistingAlbumEvent")
+enum class AlbumEvent {
+    NEW_ALBUM_EVENT, EXISTING_ALBUM_EVENT
+}
+
+class NewAlbumEvent : AbstractEvent(AlbumEvent.NEW_ALBUM_EVENT.toString())
+class ExistingAlbumEvent : AbstractEvent(AlbumEvent.EXISTING_ALBUM_EVENT.toString())
 
 enum class AlbumState {
     NEW_ALBUM,
@@ -38,7 +40,6 @@ enum class AlbumRule {
 enum class AlbumArtRules {
     NEW_MP3_ART_EXISTS,
     MP3_TAGGED_ART_UPDATED
-
 }
 
 enum class AlbumArtFacts {

--- a/src/main/kotlin/main.kt
+++ b/src/main/kotlin/main.kt
@@ -15,6 +15,7 @@ import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.FileTime
+import java.util.logging.Logger
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.exists
 
@@ -36,6 +37,8 @@ enum class AlbumRule {
 enum class AlbumFact {
     ALBUM_STATE, CURRENT_ALBUM, NEXT_ALBUM
 }
+
+val logger: Logger = Logger.getLogger("main")
 
 @ExperimentalPathApi
 fun main(args: Array<String>) {
@@ -188,19 +191,16 @@ fun shouldWeProcessThisTrack(trackData: TrackData): Boolean {
 @ExperimentalPathApi
 fun shouldWeUpdateAlbumArt(trackData: TrackData): Boolean =
     if (mp3FileExists(trackData) && albumArtPNGExists(trackData) && Tag.albumArtTagExists(trackData.mp3FileAbsolute)) {
-        ImageScaler.logger.warning("Determination: " + isAlbumArtCurrent(trackData))
+        logger.warning("Determination: " + isAlbumArtCurrent(trackData))
         isAlbumArtCurrent(trackData)
     } else if (mp3FileExists(trackData) && albumArtPNGExists(trackData) && !Tag.albumArtTagExists(trackData.mp3FileAbsolute)) {
         true
     } else if (!mp3FileExists(trackData) && albumArtPNGExists(trackData)) {
         true
     } else if (!albumArtPNGExists(trackData)) {
-        ImageScaler.logger.warning(trackData.flacAlbumPathAbsolute.toPath().toString())
+        logger.warning(trackData.flacAlbumPathAbsolute.toPath().toString())
         false
     } else true
-
-
-
 
 fun deleteMp3CoverArt(mp3AlbumPathAbsolute: Path?): Boolean {
     if (mp3AlbumPathAbsolute != null) {

--- a/src/main/kotlin/rules/AlbumArtRule.kt
+++ b/src/main/kotlin/rules/AlbumArtRule.kt
@@ -1,7 +1,10 @@
 package com.eigenholser.flac2mp3.rules
 
-import com.eigenholser.flac2mp3.*
-import org.jeasy.rules.api.Fact
+import com.eigenholser.flac2mp3.AlbumArtFacts
+import com.eigenholser.flac2mp3.ImageScaler
+import com.eigenholser.flac2mp3.Tag
+import com.eigenholser.flac2mp3.TrackData
+import com.eigenholser.flac2mp3.states.AlbumStates
 import org.jeasy.rules.api.Facts
 import org.jeasy.rules.api.Rule
 import org.jeasy.states.api.FiniteStateMachine
@@ -11,14 +14,14 @@ interface AlbumArtRule: Rule {
 
     override fun execute(facts: Facts) {
         val trackData = facts.get<TrackData>(AlbumArtFacts.TRACK_DATA.toString())
-        when (AlbumState.valueOf(facts.get<FiniteStateMachine>(AlbumArtFacts.ALBUM_STATE.toString()).currentState.name)) {
-            AlbumState.NEW_ALBUM -> {
+        when (AlbumStates.valueOf(facts.get<FiniteStateMachine>(AlbumArtFacts.ALBUM_STATE.toString()).currentState.name)) {
+            AlbumStates.NEW_ALBUM -> {
                 ImageScaler.scaleImage(
                     trackData.flacAlbumPathAbsolute.toString(),
                     trackData.mp3AlbumPathAbsolute.toString()
                 )
             }
-            AlbumState.EXISTING_ALBUM -> {
+            AlbumStates.EXISTING_ALBUM -> {
                 Tag.updateAlbumArtField(
                     trackData.mp3FileAbsolute.toString(),
                     trackData.mp3AlbumPathAbsolute.toString()

--- a/src/main/kotlin/rules/AlbumArtRule.kt
+++ b/src/main/kotlin/rules/AlbumArtRule.kt
@@ -1,0 +1,41 @@
+package com.eigenholser.flac2mp3.rules
+
+import com.eigenholser.flac2mp3.*
+import org.jeasy.rules.api.Fact
+import org.jeasy.rules.api.Facts
+import org.jeasy.rules.api.Rule
+import org.jeasy.states.api.FiniteStateMachine
+
+interface AlbumArtRule: Rule {
+    val rulePriority: Int
+
+    override fun execute(facts: Facts) {
+        val trackData = facts.get<TrackData>(AlbumArtFacts.TRACK_DATA.toString())
+        when (AlbumState.valueOf(facts.get<FiniteStateMachine>(AlbumArtFacts.ALBUM_STATE.toString()).currentState.name)) {
+            AlbumState.NEW_ALBUM -> {
+                ImageScaler.scaleImage(
+                    trackData.flacAlbumPathAbsolute.toString(),
+                    trackData.mp3AlbumPathAbsolute.toString()
+                )
+            }
+            AlbumState.EXISTING_ALBUM -> {
+                Tag.updateAlbumArtField(
+                    trackData.mp3FileAbsolute.toString(),
+                    trackData.mp3AlbumPathAbsolute.toString()
+                )
+            }
+        }
+    }
+
+    override fun getPriority(): Int {
+        return rulePriority
+    }
+
+    override fun compareTo(other: Rule): Int {
+        return when {
+            this.priority > other.priority -> 1
+            this.priority < other.priority -> -1
+            else -> this.name.compareTo(other.name)
+        }
+    }
+}

--- a/src/main/kotlin/rules/ArtNewMp3.kt
+++ b/src/main/kotlin/rules/ArtNewMp3.kt
@@ -1,0 +1,23 @@
+package com.eigenholser.flac2mp3.rules
+
+import com.eigenholser.flac2mp3.*
+import org.jeasy.rules.api.Facts
+import kotlin.io.path.ExperimentalPathApi
+
+class ArtNewMp3: AlbumArtRule {
+    override val rulePriority = 1
+
+    override fun getName(): String {
+        return AlbumArtRules.NEW_MP3_ART_EXISTS.toString()
+    }
+
+    override fun getDescription(): String {
+        return "New MP3 file and album art PNG exists in FLAC album."
+    }
+
+    @OptIn(ExperimentalPathApi::class)
+    override fun evaluate(facts: Facts): Boolean {
+        val trackData = facts.get<TrackData>(AlbumArtFacts.TRACK_DATA.toString())
+        return !mp3FileExists(trackData) && albumArtPNGExists(trackData)
+    }
+}

--- a/src/main/kotlin/rules/ArtUpdateIDv3.kt
+++ b/src/main/kotlin/rules/ArtUpdateIDv3.kt
@@ -1,0 +1,21 @@
+package com.eigenholser.flac2mp3.rules
+
+import com.eigenholser.flac2mp3.*
+import org.jeasy.rules.api.Facts
+
+class ArtUpdateIDv3: AlbumArtRule {
+    override val rulePriority = 2
+
+    override fun getName(): String {
+        return AlbumArtRules.MP3_TAGGED_ART_UPDATED.toString()
+    }
+
+    override fun getDescription(): String {
+        return "Existing MP3 file has album art tag and album art PNG updated in FLAC album."
+    }
+
+    override fun evaluate(facts: Facts): Boolean {
+        val trackData = facts.get<TrackData>(AlbumArtFacts.TRACK_DATA.toString())
+        return isAlbumArtUpdated(trackData)
+    }
+}

--- a/src/main/kotlin/rules/ConversionRule.kt
+++ b/src/main/kotlin/rules/ConversionRule.kt
@@ -1,0 +1,17 @@
+package com.eigenholser.flac2mp3.rules
+
+import org.jeasy.rules.api.Fact
+import org.jeasy.rules.api.Facts
+import org.jeasy.rules.api.Rule
+
+interface ConversionRule: Rule {
+    override fun execute(facts: Facts) = facts.add(Fact(name, true))
+
+    override fun compareTo(other: Rule): Int {
+        return when {
+            this.priority > other.priority -> 1
+            this.priority < other.priority -> -1
+            else -> this.name.compareTo(other.name)
+        }
+    }
+}

--- a/src/main/kotlin/rules/NewAlbum.kt
+++ b/src/main/kotlin/rules/NewAlbum.kt
@@ -3,12 +3,21 @@ package com.eigenholser.flac2mp3.rules
 import com.eigenholser.flac2mp3.AlbumFact
 import com.eigenholser.flac2mp3.AlbumRule
 import com.eigenholser.flac2mp3.AlbumState
+import com.eigenholser.flac2mp3.NewAlbumEvent
 import org.jeasy.rules.api.Facts
 import org.jeasy.states.api.FiniteStateMachine
 
-class NewAlbum: ConversionRule {
+class NewAlbum(private val albumStateMachine: FiniteStateMachine): ConversionRule {
     override fun getName(): String {
         return AlbumRule.NEW_ALBUM.toString()
+    }
+
+    override fun getDescription(): String {
+        return "Determines whether current track represents a transition to a new album."
+    }
+
+    override fun execute(facts: Facts) {
+        albumStateMachine.fire(NewAlbumEvent())
     }
 
     override fun evaluate(facts: Facts): Boolean {

--- a/src/main/kotlin/rules/NewAlbum.kt
+++ b/src/main/kotlin/rules/NewAlbum.kt
@@ -1,0 +1,21 @@
+package com.eigenholser.flac2mp3.rules
+
+import com.eigenholser.flac2mp3.AlbumFact
+import com.eigenholser.flac2mp3.AlbumRule
+import com.eigenholser.flac2mp3.AlbumState
+import org.jeasy.rules.api.Facts
+import org.jeasy.states.api.FiniteStateMachine
+
+class NewAlbum: ConversionRule {
+    override fun getName(): String {
+        return AlbumRule.NEW_ALBUM.toString()
+    }
+
+    override fun evaluate(facts: Facts): Boolean {
+        val albumState = facts.get<FiniteStateMachine>(AlbumFact.ALBUM_STATE.toString())
+        val currentAlbum = facts.get<String>(AlbumFact.CURRENT_ALBUM.toString())
+        val nextAlbum = facts.get<String>(AlbumFact.NEXT_ALBUM.toString())
+
+        return AlbumState.valueOf(albumState.currentState.name) == AlbumState.EXISTING_ALBUM && currentAlbum != nextAlbum
+    }
+}

--- a/src/main/kotlin/rules/NewAlbum.kt
+++ b/src/main/kotlin/rules/NewAlbum.kt
@@ -2,8 +2,8 @@ package com.eigenholser.flac2mp3.rules
 
 import com.eigenholser.flac2mp3.AlbumFact
 import com.eigenholser.flac2mp3.AlbumRule
-import com.eigenholser.flac2mp3.AlbumState
-import com.eigenholser.flac2mp3.NewAlbumEvent
+import com.eigenholser.flac2mp3.states.AlbumStates
+import com.eigenholser.flac2mp3.states.NewAlbumEvent
 import org.jeasy.rules.api.Facts
 import org.jeasy.states.api.FiniteStateMachine
 
@@ -25,6 +25,6 @@ class NewAlbum(private val albumStateMachine: FiniteStateMachine): ConversionRul
         val currentAlbum = facts.get<String>(AlbumFact.CURRENT_ALBUM.toString())
         val nextAlbum = facts.get<String>(AlbumFact.NEXT_ALBUM.toString())
 
-        return AlbumState.valueOf(albumState.currentState.name) == AlbumState.EXISTING_ALBUM && currentAlbum != nextAlbum
+        return AlbumStates.valueOf(albumState.currentState.name) == AlbumStates.EXISTING_ALBUM && currentAlbum != nextAlbum
     }
 }

--- a/src/main/kotlin/rules/RulesCommon.kt
+++ b/src/main/kotlin/rules/RulesCommon.kt
@@ -1,0 +1,20 @@
+package com.eigenholser.flac2mp3.rules
+
+enum class AlbumRule {
+    NEW_ALBUM
+}
+
+enum class AlbumArtRules {
+    NEW_MP3_ART_EXISTS,
+    MP3_TAGGED_ART_UPDATED
+}
+
+enum class AlbumArtFacts {
+    TRACK_DATA, ALBUM_STATE
+}
+enum class AlbumFact {
+    ALBUM_STATE, CURRENT_ALBUM, NEXT_ALBUM
+}
+
+object ConversionLib {
+}

--- a/src/main/kotlin/states/AlbumState.kt
+++ b/src/main/kotlin/states/AlbumState.kt
@@ -1,0 +1,48 @@
+package com.eigenholser.flac2mp3.states
+
+import org.jeasy.states.api.AbstractEvent
+import org.jeasy.states.api.State
+import org.jeasy.states.core.FiniteStateMachineBuilder
+import org.jeasy.states.core.TransitionBuilder
+import java.nio.file.Path
+
+enum class AlbumEvent {
+    NEW_ALBUM_EVENT, EXISTING_ALBUM_EVENT
+}
+
+enum class AlbumStates {
+    NEW_ALBUM,
+    EXISTING_ALBUM
+}
+
+data class ConversionState(var nextAlbum: String = "", var prevMp3AlbumPath: Path? = null)
+class NewAlbumEvent : AbstractEvent(AlbumEvent.NEW_ALBUM_EVENT.toString())
+class ExistingAlbumEvent : AbstractEvent(AlbumEvent.EXISTING_ALBUM_EVENT.toString())
+
+object AlbumState {
+    val state = ConversionState()
+    val newAlbum = State(AlbumStates.NEW_ALBUM.toString())
+    val existingAlbum = State(AlbumStates.EXISTING_ALBUM.toString())
+    val states = mutableSetOf(newAlbum, existingAlbum)
+
+    val newAlbumTx = TransitionBuilder()
+        .name(AlbumStates.NEW_ALBUM.toString())
+        .sourceState(existingAlbum)
+        .eventType(NewAlbumEvent::class.java)
+        .eventHandler(SwitchAlbum())
+        .targetState(newAlbum)
+        .build()
+
+    val existingAlbumTx = TransitionBuilder()
+        .name(AlbumStates.EXISTING_ALBUM.toString())
+        .sourceState(newAlbum)
+        .eventType(ExistingAlbumEvent::class.java)
+        .eventHandler(SwitchAlbum())
+        .targetState(existingAlbum)
+        .build()
+
+    val albumStateMachine = FiniteStateMachineBuilder(states, existingAlbum)
+        .registerTransition(newAlbumTx)
+        .registerTransition(existingAlbumTx)
+        .build()
+}

--- a/src/main/kotlin/states/SwitchAlbum.kt
+++ b/src/main/kotlin/states/SwitchAlbum.kt
@@ -2,9 +2,15 @@ package com.eigenholser.flac2mp3.states
 
 import org.jeasy.states.api.AbstractEvent
 import org.jeasy.states.api.EventHandler
+import java.util.logging.Logger
 
 class SwitchAlbum: EventHandler<AbstractEvent> {
     override fun handleEvent(event: AbstractEvent?) {
-        println("SwitchAlbum: Notified of event: {}".format(event?.name))
+        logger.info("SwitchAlbum: Notified of event: ${event?.name}")
+    }
+
+    companion object {
+        private val logger: Logger = Logger.getLogger("SwitchAlbum")
     }
 }
+

--- a/src/main/kotlin/states/SwitchAlbum.kt
+++ b/src/main/kotlin/states/SwitchAlbum.kt
@@ -1,0 +1,10 @@
+package com.eigenholser.flac2mp3.states
+
+import org.jeasy.states.api.AbstractEvent
+import org.jeasy.states.api.EventHandler
+
+class SwitchAlbum: EventHandler<AbstractEvent> {
+    override fun handleEvent(event: AbstractEvent?) {
+        println("SwitchAlbum: Notified of event: {}".format(event?.name))
+    }
+}


### PR DESCRIPTION
This PR disables the database but does not remove it. The idea is to use the filesystem to determine state. This is attractive from a complexity point of view. It is mildly unattractive from a precision point of view. e.g. Determining whether the album art has been updated is accomplished by comparing the timestamps of the _one_ MP3 file and the album art. Clumsy but, hey, how often are ya gonna update album art? Future developments may resurrect the DB so that code stays for now.

Implemented rules-based approach to logic.